### PR TITLE
feat: add Swagger (OpenAPI) documentation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/diegobustos/my_task_planner_backend/config/SwaggerConfig.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package diegobustos.my_task_planner_backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("My Task Planner API")
+                        .version("1.0")
+                        .description("Documentation for My Task Planner Backend API"));
+    }
+}


### PR DESCRIPTION
Integrates Swagger (OpenAPI 3) to provide an interactive and always up-to-date API documentation interface.

**What's included:**

- Auto-generated documentation for REST endpoints

- Swagger UI available at /swagger-ui/index.html

- Custom metadata for the API (title, version, description)

This helps both frontend developers and QA teams test endpoints directly, and ensures easier onboarding and maintenance.