### PR TITLE
feat: board functionalities

### DIFF
--- a/src/main/java/diegobustos/my_task_planner_backend/advice/GlobalExceptionHandler.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/advice/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package diegobustos.my_task_planner_backend.advice;
 
 
+import diegobustos.my_task_planner_backend.exception.BoardNotFoundException;
 import diegobustos.my_task_planner_backend.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +49,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleUserNotFound(UserNotFoundException ex) {
+        Map<String, String> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(BoardNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleBoardNotFound(BoardNotFoundException ex) {
         Map<String, String> body = new HashMap<>();
         body.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);

--- a/src/main/java/diegobustos/my_task_planner_backend/controller/BoardController.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/controller/BoardController.java
@@ -1,0 +1,184 @@
+package diegobustos.my_task_planner_backend.controller;
+
+import diegobustos.my_task_planner_backend.dto.BoardRequest;
+import diegobustos.my_task_planner_backend.dto.BoardResponse;
+import diegobustos.my_task_planner_backend.service.BoardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/board")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @Operation (
+            summary = "Create board",
+            description = "Creates a new board for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses (value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Board created successfully.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BoardResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request payload (e.g., missing or blank fields).",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"Title is required\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "User not found.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"User not found\"}")
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"An unexpected error occurred\"}")
+                    )
+            )
+    })
+    @PostMapping()
+    public ResponseEntity<BoardResponse> createBoard(
+            @RequestBody @Valid BoardRequest request
+    ) {
+        return ResponseEntity.ok(boardService.createBoard(request));
+    }
+
+    @Operation(
+            summary = "Get all boards",
+            description = "Retrieves all boards for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Boards retrieved successfully.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BoardResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "User not found.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"User not found\"}")
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"An unexpected error occurred\"}")
+                    )
+            )
+    })
+    @GetMapping("/me")
+    public ResponseEntity<Page<BoardResponse>> getAllBoards(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(boardService.getAllBoards(page, size));
+    }
+
+    @Operation(
+            summary = "Update board by Id",
+            description = "Updates a board by its ID for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Board updated successfully.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BoardResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request payload (e.g., missing or blank fields).",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"Title is required\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Board not found.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"Board not found\"}")
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"An unexpected error occurred\"}")
+                    )
+            )
+    })
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<BoardResponse> updateBoard(
+            @PathVariable Long id,
+            @RequestBody @Valid BoardRequest request
+    ) {
+        return ResponseEntity.ok(boardService.updateBoard(id, request));
+    }
+
+    @Operation(
+            summary = "Delete board by Id",
+            description = "Deletes a board by its ID for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Board deleted successfully."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Board not found.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"Board not found\"}")
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"message\": \"An unexpected error occurred\"}")
+                    )
+            )
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBoard(@PathVariable Long id) {
+        boardService.deleteBoard(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/dto/BoardRequest.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/dto/BoardRequest.java
@@ -1,0 +1,16 @@
+package diegobustos.my_task_planner_backend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardRequest {
+    @Schema(description = "Board Title.", example = "Personal Tasks", required = true)
+    @NotBlank(message = "Title is required")
+    private String title;
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/dto/BoardResponse.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/dto/BoardResponse.java
@@ -1,0 +1,25 @@
+package diegobustos.my_task_planner_backend.dto;
+
+import diegobustos.my_task_planner_backend.entity.Board;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardResponse {
+    @Schema(description = "Board ID.", example = "1")
+    private Long id;
+
+    @Schema(description = "Board Title.", example = "Personal Tasks")
+    private String title;
+
+    public static  BoardResponse fromEntity(Board board) {
+        return BoardResponse.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/entity/Board.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/entity/Board.java
@@ -1,0 +1,37 @@
+package diegobustos.my_task_planner_backend.entity;
+
+import diegobustos.my_task_planner_backend.entity.common.AuditableEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Board extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Board ID.", example = "1")
+    private Long id;
+
+    @Column(nullable = false)
+    @Schema(description = "Board Title.", example = "Personal Tasks")
+    private String title;
+
+    @Builder.Default
+    @OneToMany(
+            mappedBy = "board",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @Schema(description = "List of users associated with the board.")
+    private List<UserBoard> users = new ArrayList<>();
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/entity/User.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/entity/User.java
@@ -8,6 +8,9 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
@@ -43,4 +46,13 @@ public class User extends AuditableEntity {
     @NotBlank(message = "Password is required")
     @Schema(description = "Encrypted user password.", example = "$2a$10$...")
     private String password;
+
+    @Builder.Default
+    @OneToMany(
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    @Schema(description = "List of boards associated with the user.")
+    private List<UserBoard> boards = new ArrayList<>();
 }

--- a/src/main/java/diegobustos/my_task_planner_backend/entity/UserBoard.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/entity/UserBoard.java
@@ -1,0 +1,33 @@
+package diegobustos.my_task_planner_backend.entity;
+
+import diegobustos.my_task_planner_backend.entity.common.AuditableEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBoard extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Intermediate class ID.", example = "1")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Schema(description = "User associated with the board.", example = "2")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    @Schema(description = "Board associated with the user.", example = "3")
+    private Board board;
+
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/exception/BoardNotFoundException.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/exception/BoardNotFoundException.java
@@ -1,0 +1,7 @@
+package diegobustos.my_task_planner_backend.exception;
+
+public class BoardNotFoundException extends RuntimeException {
+    public BoardNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/repository/BoardRepository.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/repository/BoardRepository.java
@@ -1,0 +1,15 @@
+package diegobustos.my_task_planner_backend.repository;
+
+import diegobustos.my_task_planner_backend.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    @Query("SELECT b FROM Board b JOIN b.users ub WHERE ub.user.email = :email AND b.deletedAt IS NULL ORDER BY b.createdAt DESC")
+    Page<Board> findByUserEmail(String email, Pageable pageable);
+
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/repository/UserBoardRepository.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/repository/UserBoardRepository.java
@@ -1,0 +1,9 @@
+package diegobustos.my_task_planner_backend.repository;
+
+import diegobustos.my_task_planner_backend.entity.UserBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBoardRepository extends JpaRepository<UserBoard, Long> {
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/service/BoardService.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/service/BoardService.java
@@ -1,0 +1,90 @@
+package diegobustos.my_task_planner_backend.service;
+
+import diegobustos.my_task_planner_backend.dto.BoardRequest;
+import diegobustos.my_task_planner_backend.dto.BoardResponse;
+import diegobustos.my_task_planner_backend.entity.Board;
+import diegobustos.my_task_planner_backend.entity.User;
+import diegobustos.my_task_planner_backend.entity.UserBoard;
+import diegobustos.my_task_planner_backend.exception.BoardNotFoundException;
+import diegobustos.my_task_planner_backend.exception.UserNotFoundException;
+import diegobustos.my_task_planner_backend.repository.BoardRepository;
+import diegobustos.my_task_planner_backend.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final UserRepository userRepository;
+    private final UserBoardService userBoardService;
+    private final BoardRepository boardRepository;
+
+
+    @Transactional
+    public BoardResponse createBoard(BoardRequest request){
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+
+        Board board = Board.builder()
+                .title(request.getTitle())
+                .build();
+
+        boardRepository.save(board);
+
+        userBoardService.createUserBoard(user, board);
+
+        return BoardResponse.fromEntity(board);
+    }
+
+    public Page<BoardResponse> getAllBoards(int page, int size) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<Board> boards = boardRepository.findByUserEmail(email, pageable);
+        return boards.map(BoardResponse::fromEntity);
+    }
+
+    public BoardResponse updateBoard(Long boardId, BoardRequest request) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+
+        Board board = user.getBoards().stream()
+                .map(UserBoard::getBoard)
+                .filter(b -> b.getId().equals(boardId) && b.getDeletedAt() == null)
+                .findFirst()
+                .orElseThrow(() -> new BoardNotFoundException("Board not found"));
+
+        board.setTitle(request.getTitle());
+        boardRepository.save(board);
+
+        return BoardResponse.fromEntity(board);
+    }
+
+    public void deleteBoard(Long boardId) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+
+        Board board = user.getBoards().stream()
+                .map(UserBoard::getBoard)
+                .filter(b -> b.getId().equals(boardId) && b.getDeletedAt() == null)
+                .findFirst()
+                .orElseThrow(() -> new BoardNotFoundException("Board not found"));
+
+        board.setDeletedAt(Instant.now());
+        boardRepository.save(board);
+    }
+}

--- a/src/main/java/diegobustos/my_task_planner_backend/service/UserBoardService.java
+++ b/src/main/java/diegobustos/my_task_planner_backend/service/UserBoardService.java
@@ -1,0 +1,37 @@
+package diegobustos.my_task_planner_backend.service;
+
+import diegobustos.my_task_planner_backend.entity.Board;
+import diegobustos.my_task_planner_backend.entity.User;
+import diegobustos.my_task_planner_backend.entity.UserBoard;
+import diegobustos.my_task_planner_backend.repository.UserBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserBoardService {
+
+    private final UserBoardRepository userBoardRepository;
+
+    public UserBoard createUserBoard(User user, Board board) {
+        if (user == null) {
+            throw new IllegalArgumentException("User cannot be null");
+        }
+
+        if (board == null) {
+            throw new IllegalArgumentException("Board cannot be null");
+        }
+
+        UserBoard userBoard = UserBoard.builder()
+                .user(user)
+                .board(board)
+                .build();
+
+        userBoardRepository.save(userBoard);
+
+        board.getUsers().add(userBoard);
+        user.getBoards().add(userBoard);
+
+        return userBoard;
+    }
+}

--- a/src/test/java/diegobustos/my_task_planner_backend/slice/BoardControllerTest.java
+++ b/src/test/java/diegobustos/my_task_planner_backend/slice/BoardControllerTest.java
@@ -1,0 +1,255 @@
+package diegobustos.my_task_planner_backend.slice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import diegobustos.my_task_planner_backend.config.JwtFilter;
+import diegobustos.my_task_planner_backend.controller.BoardController;
+import diegobustos.my_task_planner_backend.dto.BoardRequest;
+import diegobustos.my_task_planner_backend.dto.BoardResponse;
+import diegobustos.my_task_planner_backend.exception.BoardNotFoundException;
+import diegobustos.my_task_planner_backend.exception.UserNotFoundException;
+import diegobustos.my_task_planner_backend.service.BoardService;
+import diegobustos.my_task_planner_backend.service.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = BoardController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
+class BoardControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @MockitoBean
+    BoardService boardService;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    JwtFilter jwtFilter;
+
+    @Nested
+    @DisplayName("POST /api/v1/board")
+    class CreateBoard {
+
+        @Test
+        @DisplayName("should return 200 and response body when request is valid")
+        void whenValidRequest_thenReturn200() throws Exception {
+            BoardRequest request = new BoardRequest("My Board");
+            BoardResponse response = new BoardResponse(1L, "My Board");
+
+            when(boardService.createBoard(any())).thenReturn(response);
+
+            mockMvc.perform(post("/api/v1/board")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.title").value("My Board"));
+        }
+
+        @Test
+        @DisplayName("should return 400 when title is blank")
+        void whenTitleIsBlank_thenReturn400() throws Exception {
+            BoardRequest request = new BoardRequest("");
+
+            mockMvc.perform(post("/api/v1/board")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("should return 404 when user not found")
+        void whenUserNotFound_thenReturn404() throws Exception {
+            BoardRequest request = new BoardRequest("My Board");
+
+            doThrow(new UserNotFoundException("User not found"))
+                    .when(boardService).createBoard(any());
+
+            mockMvc.perform(post("/api/v1/board")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("User not found"));
+        }
+
+        @Test
+        @DisplayName("should return 500 on unexpected error")
+        void whenUnexpectedError_thenReturn500() throws Exception {
+            BoardRequest request = new BoardRequest("My Board");
+
+            doThrow(new RuntimeException())
+                    .when(boardService).createBoard(any());
+
+            mockMvc.perform(post("/api/v1/board")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/board/me")
+    class GetAllBoards {
+
+        @Test
+        @DisplayName("should return 200 and list of boards")
+        void whenBoardsExist_thenReturn200() throws Exception {
+            BoardResponse response = new BoardResponse(1L, "Board 1");
+            PageImpl<BoardResponse> page = new PageImpl<>(
+                    Collections.singletonList(response),
+                    PageRequest.of(0, 10),
+                    1
+            );
+
+            when(boardService.getAllBoards(0, 10)).thenReturn(page);
+
+            mockMvc.perform(get("/api/v1/board/me"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].id").value(1L))
+                    .andExpect(jsonPath("$.content[0].title").value("Board 1"));
+        }
+
+        @Test
+        @DisplayName("should return 404 when user not found")
+        void whenUserNotFound_thenReturn404() throws Exception {
+            doThrow(new UserNotFoundException("User not found"))
+                    .when(boardService).getAllBoards(0, 10);
+
+            mockMvc.perform(get("/api/v1/board/me"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("User not found"));
+        }
+
+        @Test
+        @DisplayName("should return 500 on unexpected error")
+        void whenUnexpectedError_thenReturn500() throws Exception {
+            doThrow(new RuntimeException())
+                    .when(boardService).getAllBoards(0, 10);
+
+            mockMvc.perform(get("/api/v1/board/me"))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/board/{id}")
+    class UpdateBoard {
+
+        @Test
+        @DisplayName("should return 200 and updated board")
+        void whenValidUpdate_thenReturn200() throws Exception {
+            BoardRequest request = new BoardRequest("Updated Board");
+            BoardResponse response = new BoardResponse(1L, "Updated Board");
+
+            when(boardService.updateBoard(eq(1L), any(BoardRequest.class))).thenReturn(response);
+
+            mockMvc.perform(patch("/api/v1/board/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.title").value("Updated Board"));
+        }
+
+        @Test
+        @DisplayName("should return 400 when title is blank")
+        void whenTitleIsBlank_thenReturn400() throws Exception {
+            BoardRequest request = new BoardRequest("");
+
+            mockMvc.perform(patch("/api/v1/board/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("should return 404 when board not found")
+        void whenBoardNotFound_thenReturn404() throws Exception {
+            BoardRequest request = new BoardRequest("Updated Board");
+
+            doThrow(new BoardNotFoundException("Board not found"))
+                    .when(boardService).updateBoard(eq(1L), any(BoardRequest.class));
+
+            mockMvc.perform(patch("/api/v1/board/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("Board not found"));
+        }
+
+        @Test
+        @DisplayName("should return 500 on unexpected error")
+        void whenUnexpectedError_thenReturn500() throws Exception {
+            BoardRequest request = new BoardRequest("Updated Board");
+
+            doThrow(new RuntimeException())
+                    .when(boardService).updateBoard(eq(1L), any(BoardRequest.class));
+
+            mockMvc.perform(patch("/api/v1/board/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(request)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/board/{id}")
+    class DeleteBoard {
+
+        @Test
+        @DisplayName("should return 204 when board is deleted")
+        void whenBoardExists_thenReturn204() throws Exception {
+            mockMvc.perform(delete("/api/v1/board/1"))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("should return 404 when board not found")
+        void whenBoardNotFound_thenReturn404() throws Exception {
+            doThrow(new BoardNotFoundException("Board not found"))
+                    .when(boardService).deleteBoard(1L);
+
+            mockMvc.perform(delete("/api/v1/board/1"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value("Board not found"));
+        }
+
+        @Test
+        @DisplayName("should return 500 on unexpected error")
+        void whenUnexpectedError_thenReturn500() throws Exception {
+            doThrow(new RuntimeException())
+                    .when(boardService).deleteBoard(1L);
+
+            mockMvc.perform(delete("/api/v1/board/1"))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+        }
+    }
+}

--- a/src/test/java/diegobustos/my_task_planner_backend/unit/BoardServiceTest.java
+++ b/src/test/java/diegobustos/my_task_planner_backend/unit/BoardServiceTest.java
@@ -1,0 +1,165 @@
+package diegobustos.my_task_planner_backend.unit;
+
+import diegobustos.my_task_planner_backend.dto.BoardRequest;
+import diegobustos.my_task_planner_backend.dto.BoardResponse;
+import diegobustos.my_task_planner_backend.entity.Board;
+import diegobustos.my_task_planner_backend.entity.User;
+import diegobustos.my_task_planner_backend.entity.UserBoard;
+import diegobustos.my_task_planner_backend.exception.BoardNotFoundException;
+import diegobustos.my_task_planner_backend.exception.UserNotFoundException;
+import diegobustos.my_task_planner_backend.repository.BoardRepository;
+import diegobustos.my_task_planner_backend.repository.UserRepository;
+import diegobustos.my_task_planner_backend.service.BoardService;
+import diegobustos.my_task_planner_backend.service.UserBoardService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BoardServiceTest {
+
+    @InjectMocks
+    BoardService boardService;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private UserBoardService userBoardService;
+
+    @Mock
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    void createBoard_success() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        User user = User.builder().email(email).build();
+        BoardRequest request = new BoardRequest("New Board");
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(boardRepository.save(any(Board.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        BoardResponse response = boardService.createBoard(request);
+
+        assertEquals("New Board", response.getTitle());
+        verify(boardRepository).save(any(Board.class));
+        verify(userBoardService).createUserBoard(eq(user), any(Board.class));
+    }
+
+    @Test
+    void createBoard_userNotFound() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        BoardRequest request = new BoardRequest("New Board");
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        UserNotFoundException ex = assertThrows(UserNotFoundException.class,
+                () -> boardService.createBoard(request));
+        assertEquals("User not found", ex.getMessage());
+    }
+
+    @Test
+    void updateBoard_success() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        User user = User.builder().email(email).build();
+        Board board = Board.builder().id(1L).title("Old Title").build();
+        UserBoard userBoard = UserBoard.builder().user(user).board(board).build();
+        user.getBoards().add(userBoard);
+
+        BoardRequest request = new BoardRequest("New Title");
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(boardRepository.save(board)).thenReturn(board);
+
+        BoardResponse response = boardService.updateBoard(1L, request);
+
+        assertEquals("New Title", response.getTitle());
+        verify(boardRepository).save(board);
+    }
+
+    @Test
+    void updateBoard_boardNotFound() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        User user = User.builder().email(email).build();
+        Board board = Board.builder().id(2L).title("Old Title").build();
+        UserBoard userBoard = UserBoard.builder().user(user).board(board).build();
+        user.getBoards().add(userBoard);
+
+        BoardRequest request = new BoardRequest("New Title");
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        BoardNotFoundException ex = assertThrows(BoardNotFoundException.class,
+                () -> boardService.updateBoard(1L, request));
+        assertEquals("Board not found", ex.getMessage());
+    }
+
+    @Test
+    void deleteBoard_success() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        User user = User.builder().email(email).build();
+        Board board = Board.builder().id(1L).title("My Board").build();
+        UserBoard userBoard = UserBoard.builder().user(user).board(board).build();
+        user.getBoards().add(userBoard);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(boardRepository.save(board)).thenReturn(board);
+
+        boardService.deleteBoard(1L);
+
+        assertNotNull(board.getDeletedAt());
+        verify(boardRepository).save(board);
+    }
+
+    @Test
+    void deleteBoard_boardNotFound() {
+        String email = "test@example.com";
+        when(authentication.getName()).thenReturn(email);
+
+        User user = User.builder().email(email).build();
+        Board board = Board.builder().id(2L).title("My Board").build();
+        UserBoard userBoard = UserBoard.builder().user(user).board(board).build();
+        user.getBoards().add(userBoard);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        BoardNotFoundException ex = assertThrows(BoardNotFoundException.class,
+                () -> boardService.deleteBoard(1L));
+        assertEquals("Board not found", ex.getMessage());
+    }
+}

--- a/src/test/java/diegobustos/my_task_planner_backend/unit/UserBoardServiceTest.java
+++ b/src/test/java/diegobustos/my_task_planner_backend/unit/UserBoardServiceTest.java
@@ -1,0 +1,65 @@
+package diegobustos.my_task_planner_backend.unit;
+
+import diegobustos.my_task_planner_backend.entity.Board;
+import diegobustos.my_task_planner_backend.entity.User;
+import diegobustos.my_task_planner_backend.entity.UserBoard;
+import diegobustos.my_task_planner_backend.repository.UserBoardRepository;
+import diegobustos.my_task_planner_backend.service.UserBoardService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserBoardServiceTest {
+
+    @InjectMocks
+    UserBoardService userBoardService;
+
+    @Mock
+    private UserBoardRepository userBoardRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createUserBoard_success() {
+        User user = User.builder().id(1L).email("test@example.com").build();
+        Board board = Board.builder().id(1L).title("Test Board").build();
+
+        when(userBoardRepository.save(any(UserBoard.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserBoard result = userBoardService.createUserBoard(user, board);
+
+        assertEquals(user, result.getUser());
+        assertEquals(board, result.getBoard());
+        assertTrue(user.getBoards().contains(result));
+        assertTrue(board.getUsers().contains(result));
+        verify(userBoardRepository).save(result);
+    }
+
+    @Test
+    void createUserBoard_nullUser() {
+        Board board = Board.builder().id(1L).title("Test Board").build();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> userBoardService.createUserBoard(null, board));
+        assertEquals("User cannot be null", ex.getMessage());
+    }
+
+    @Test
+    void createUserBoard_nullBoard() {
+        User user = User.builder().id(1L).email("test@example.com").build();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> userBoardService.createUserBoard(user, null));
+        assertEquals("Board cannot be null", ex.getMessage());
+    }
+}


### PR DESCRIPTION
- Added endpoint for board creation.
- Added endpoint for retrieve user related boards.
- Added endpoint for update and delete board.

Notes:

- Users can only create, update or delete boards related to its id.
- Board recovery is paginated with size and page parameters.